### PR TITLE
Add support for export control block

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -527,7 +527,16 @@ class SolaredgeModbusHub:
                 importvarhq4c, abs(energyvarsf)
             )
 
-            return True
+            validValue = exported > 0
+            try:
+                float(exported)
+            except:
+                validValue = false
+
+            if validValue:
+                return True
+            else:
+                return False
         else:
             return False
 
@@ -647,7 +656,17 @@ class SolaredgeModbusHub:
             statusvendor = decoder.decode_16bit_int()
             self.data["statusvendor"] = statusvendor
 
-            return True
+            #create validValue to test if data received is valid
+            validValue = acenergy > 0
+            try:
+                float(acenergy)
+            except:
+                validValue = false
+
+            if validValue:
+                return True
+            else:
+                return False
         else:
             return False
 
@@ -775,32 +794,39 @@ class SolaredgeModbusHub:
             )
 
             #0x6C - 2 - avg temp C
-            self.data[battery_prefix + 'temp_avg'] = round(decoder.decode_32bit_float(), 1)
+            tempavg = decoder.decode_32bit_float()
             #0x6E - 2 - max temp C
-            self.data[battery_prefix + 'temp_max'] = round(decoder.decode_32bit_float(), 1)
-
+            tempmax = decoder.decode_32bit_float()
             #0x70 - 2 - inst voltage V
-            self.data[battery_prefix + 'voltage'] = round(decoder.decode_32bit_float(), 3)
+            batteryvoltage = decoder.decode_32bit_float()
             #0x72 - 2 - inst current A
-            self.data[battery_prefix + 'current'] = round(decoder.decode_32bit_float(), 3)
+            batterycurrent = decoder.decode_32bit_float()
             #0x74 - 2 - inst power W
-            self.data[battery_prefix + 'power'] = round(decoder.decode_32bit_float(), 3)
-
+            batterypower = decoder.decode_32bit_float()
             #0x76 - 4 - cumulative discharged (Wh)
-            self.data[battery_prefix + 'energy_discharged'] = round(decoder.decode_64bit_uint() / 1000, 3)
+            cumulative_discharged = decoder.decode_64bit_uint()
             #0x7a - 4 - cumulative charged (Wh)
-            self.data[battery_prefix + 'energy_charged'] = round(decoder.decode_64bit_uint() / 1000, 3)
-
+            cumulative_charged = decoder.decode_64bit_uint()
             #0x7E - 2 - current max size Wh
-            self.data[battery_prefix + 'size_max'] = round(decoder.decode_32bit_float(), 3)
+            battery_max = decoder.decode_32bit_float()
             #0x80 - 2 - available size Wh
-            self.data[battery_prefix + 'size_available'] = round(decoder.decode_32bit_float(), 3)
-
+            battery_availbable = decoder.decode_32bit_float()
             #0x82 - 2 - SoH %
-            self.data[battery_prefix + 'state_of_health'] = round(decoder.decode_32bit_float(), 0)
+            battery_SoH = decoder.decode_32bit_float()
             #0x84 - 2 - SoC %
-            self.data[battery_prefix + 'state_of_charge'] = round(decoder.decode_32bit_float(), 0)
-            #0x86 - 2 - status
+            battery_SoC = decoder.decode_32bit_float()
+
+            self.data[battery_prefix + 'temp_avg'] = round(tempavg, 1)
+            self.data[battery_prefix + 'temp_max'] = round(tempmax, 1)
+            self.data[battery_prefix + 'voltage'] = round(batteryvoltage, 3)
+            self.data[battery_prefix + 'current'] = round(batterycurrent, 3)
+            self.data[battery_prefix + 'power'] = round(batterypower, 3)
+            self.data[battery_prefix + 'energy_discharged'] = round(cumulative_discharged / 1000, 3)
+            self.data[battery_prefix + 'energy_charged'] = round(cumulative_charged / 1000, 3)
+            self.data[battery_prefix + 'size_max'] = round(battery_max, 3)
+            self.data[battery_prefix + 'size_available'] = round(battery_availbable, 3)
+            self.data[battery_prefix + 'state_of_health'] = round(battery_SoH, 0)
+            self.data[battery_prefix + 'state_of_charge'] = round(battery_SoC, 0)
             battery_status = decoder.decode_32bit_uint()
 
             # voltage and current are bogus in certain statuses
@@ -814,6 +840,20 @@ class SolaredgeModbusHub:
             else:
                 self.data[battery_prefix + 'status'] = battery_status
 
-            return True
+            #create validValue to test if data received is valid
+            #validValue = battery_SoC > 0.1
+            if battery_SoC <101 and battery_SoC > 0.1:
+                validValue = True
+            else:
+                validValue = False
+#            try:
+#                float(cumulative_discharged)
+#            except:
+#                validValue = false
+
+            if validValue:
+                return True
+            else:
+                return False
         else:
             return False

--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -544,16 +544,6 @@ class SolaredgeModbusHub:
                 importvarhq4c, abs(energyvarsf)
             )
 
-#            validValue = exported > 0
-#            try:
-#                float(exported)
-#            except:
-#                validValue = false
-
-#            if validValue:
-#                return True
-#            else:
-#                return False
             return True
         else:
             return False
@@ -674,17 +664,6 @@ class SolaredgeModbusHub:
             statusvendor = decoder.decode_16bit_int()
             self.data["statusvendor"] = statusvendor
 
-            #create validValue to test if data received is valid
-#            validValue = acenergy > 0
-#            try:
-#                float(acenergy)
-#            except:
-#                validValue = false
-
-#            if validValue:
-#                return True
-#            else:
-#                return False
             return True
         else:
             return False
@@ -860,17 +839,6 @@ class SolaredgeModbusHub:
             else:
                 self.data[battery_prefix + 'status'] = battery_status
 
-            #create validValue to test if data received is valid
-            #validValue = battery_SoC > 0.1
-#            if battery_SoC <101 and battery_SoC > 0.1:
-#                validValue = True
-#            else:
-#                validValue = False
-
-#            if validValue:
-#                return True
-#            else:
-#                return False
             return True
         else:
             return False

--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -758,6 +758,7 @@ class SolaredgeModbusHub:
             if not battery_status in [3,4,6]:
                 self.data[battery_prefix + 'voltage'] = 0
                 self.data[battery_prefix + 'current'] = 0
+                self.data[battery_prefix + 'power'] = 0
 
             if battery_status in BATTERY_STATUSSES:
                 self.data[battery_prefix + 'status'] = BATTERY_STATUSSES[battery_status]

--- a/custom_components/solaredge_modbus/const.py
+++ b/custom_components/solaredge_modbus/const.py
@@ -283,6 +283,18 @@ BATTERY_STATUSSES = {
     10: "Sleep"
 }
 
+EXPORT_CONTROL_MODE = {
+    0: "Disabled",
+    1: "Direct Export Limitation",
+    2: "Indirect Export Limitation",
+    4: "Production Limitation"
+}
+
+EXPORT_CONTROL_LIMIT_MODE = {
+    0: "Total",
+    1: "Per phase"
+}
+
 STOREDGE_CONTROL_MODE = {
     0: "Disabled",
     1: "Maximize Self Consumption",
@@ -307,6 +319,15 @@ STOREDGE_CHARGE_DISCHARGE_MODE = {
     5: "Discharge to match load",
     7: "Maximize self consumption",
 }
+
+EXPORT_CONTROL_SELECT_TYPES = [
+    ["Export control mode", "export_control_mode", 0xE000, EXPORT_CONTROL_MODE],
+    ["Export control limit mode", "export_control_limit_mode", 0xE001, EXPORT_CONTROL_LIMIT_MODE],
+]
+
+EXPORT_CONTROL_NUMBER_TYPES = [
+    ["Export control site limit", "export_control_site_limit", 0xE002, "f", {"min": 0, "max": 10000, "unit": "W"}],
+]
 
 STORAGE_SELECT_TYPES = [
     ["Storage Control Mode", "storage_contol_mode", 0xE004, STOREDGE_CONTROL_MODE],

--- a/custom_components/solaredge_modbus/number.py
+++ b/custom_components/solaredge_modbus/number.py
@@ -4,6 +4,7 @@ from typing import Optional, Dict, Any
 from .const import (
     DOMAIN,
     ATTR_MANUFACTURER,
+    EXPORT_CONTROL_NUMBER_TYPES,
     STORAGE_NUMBER_TYPES,
 )
 
@@ -32,7 +33,23 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     entities = []
 
-    if hub.read_battery1 == True or hub.read_battery2 == True:
+    # If a meter is available add export control
+    if hub.has_meter:
+        for number_info in EXPORT_CONTROL_NUMBER_TYPES:
+            number = SolarEdgeNumber(
+                hub_name,
+                hub,
+                device_info,
+                number_info[0],
+                number_info[1],
+                number_info[2],
+                number_info[3],
+                number_info[4],
+            )
+            entities.append(number)
+
+    # If a battery is available add storage control
+    if hub.has_battery:
         for number_info in STORAGE_NUMBER_TYPES:
             number = SolarEdgeNumber(
                 hub_name,

--- a/custom_components/solaredge_modbus/select.py
+++ b/custom_components/solaredge_modbus/select.py
@@ -4,6 +4,7 @@ from typing import Optional, Dict, Any
 from .const import (
     DOMAIN,
     ATTR_MANUFACTURER,
+    EXPORT_CONTROL_SELECT_TYPES,
     STORAGE_SELECT_TYPES,
 )
 
@@ -29,7 +30,22 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     entities = []
 
-    if hub.read_battery1 == True or hub.read_battery2 == True:
+    # If a meter is available add export control
+    if hub.has_meter:
+        for select_info in EXPORT_CONTROL_SELECT_TYPES:
+            select = SolarEdgeSelect(
+                hub_name,
+                hub,
+                device_info,
+                select_info[0],
+                select_info[1],
+                select_info[2],
+                select_info[3],
+            )
+            entities.append(select)
+
+    # If a battery is available add storage control
+    if hub.has_battery:
         for select_info in STORAGE_SELECT_TYPES:
             select = SolarEdgeSelect(
                 hub_name,

--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -138,6 +138,7 @@ class SolarEdgeSensor(SensorEntity):
         self._unit_of_measurement = unit
         self._icon = icon
         self._device_info = device_info
+        self._attr_state_class = STATE_CLASS_MEASUREMENT
         if self._unit_of_measurement == ENERGY_KILO_WATT_HOUR:
             self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
             self._attr_device_class = DEVICE_CLASS_ENERGY

--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -190,6 +190,12 @@ class SolarEdgeSensor(SensorEntity):
         if self._key in ["status", "statusvendor"]:
             if self.state in DEVICE_STATUSSES:
                 return {ATTR_STATUS_DESCRIPTION: DEVICE_STATUSSES[self.state]}
+        elif "battery1" in self._key:
+            if "battery1_attrs" in self._hub.data:
+                return self._hub.data["battery1_attrs"]
+        elif "battery2" in self._key:
+            if "battery2_attrs" in self._hub.data:
+                return self._hub.data["battery2_attrs"]
         return None
 
     @property

--- a/custom_components/solaredge_modbus/translations/de.json
+++ b/custom_components/solaredge_modbus/translations/de.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "title": "SolarEdge Modbus",
+    "step": {
+      "user": {
+        "title": "Konfiguriere Deine modbus-Verbindung zum SolarEdge Wechselrichter.",
+        "data": {
+          "host": "Die IP-Adresse des Solaredge Wechselrichters",
+          "name": "Das Prefix, das für die SolarEdge Sensoren verwendet werden soll",
+          "port": "Der TCP Port des SolarEdge Wechselrichters (z.B. 502)",
+          "read_meter_1": "Lese die Stände des Zähler 1 (nur für Modelle mit Zähler)",
+          "read_meter_2": "Lese die Stände des Zähler 2 (nur für Modelle mit Zähler)",
+          "read_meter_3": "Lese die Stände des Zähler 3 (nur für Modelle mit Zähler)",
+          "read_battery_1": "Lese die Daten der Batterie 1 (nur für Modelle mit Batterie)",
+          "read_battery_2": "Lese die Daten der Batterie 2 (nur für Modelle mit Batterie)",
+          "scan_interval": "Das Abfrageintervall der modbus Register in Sekunden"
+        }
+      }
+    },
+    "error": {
+      "already_configured": "Der Wechselrichter ist bereits konfiguriert.,"
+    },
+    "abort": {
+      "already_configured": "Der Wechselrichter ist bereits konfiguriert."
+    }
+  }
+}


### PR DESCRIPTION
The export control block allows control of how much power is exported
from the system to the grid. This may be useful, for example, to prevent
export if the export rate is negative.